### PR TITLE
change `cdn.jsdelivr.net` to `fastly.jsdelivr.net`

### DIFF
--- a/user.js
+++ b/user.js
@@ -10,7 +10,7 @@
 // @match        https://zujuan.xkw.com/share-paper/*
 // @icon         https://zujuan.xkw.com/favicon.ico
 // @grant        GM_notification
-// @require      https://cdn.jsdelivr.net/npm/sweetalert2@11
+// @require      https://fastly.jsdelivr.net/npm/sweetalert2@11
 // @homepage     https://github.com/bzyzh/xkw-zujuan-script
 // @license      GNU Affero General Public License v3.0
 // ==/UserScript==


### PR DESCRIPTION
The former is always down. `jsdelivr cdn`動不動就下線。
這是個小改進。
以後可能還有大的、關於別的方面的PR，比如說`单独打印答案`出的毛病。